### PR TITLE
Looting Improvements

### DIFF
--- a/scripts/commonstates/v1/LootActor.lua
+++ b/scripts/commonstates/v1/LootActor.lua
@@ -127,8 +127,13 @@ function LootActorState:Run()
         else
             -- sometimes looting will be interrupted by combat 
             -- but sometimes it will just stutter step all over the body, not sure why so we fall back on the animation bypassing loot
-
-            print("looting didn't start, retrying")
+            if not self.CurrentLootActor.IsLootInteraction then
+                print("body disappeared")
+                self.WaitForLoot = 0
+                self.BlacklistActors[self.CurrentLootActor.Guid] = Pyx.Win32.GetTickCount() + 30 * 1000
+                return true
+            end
+            print("looting didn't start, trying no-animation loot")
             Navigator.Stop()
             self.CurrentLootActor:RequestDropItems()
             return true

--- a/scripts/commonstates/v1/LootActor.lua
+++ b/scripts/commonstates/v1/LootActor.lua
@@ -12,6 +12,7 @@ function LootActorState.new()
     local self = setmetatable( { }, LootActorState)
     self.CurrentLootActor = { }
     self.BlacklistActors = { }
+    self.LootStartTime = { }
     self.Settings = { TakeLoot = true, LootRadius = 4000, SkipLootPlayer = false, LogLoot = false, IgnoreBodyName = {}}
     self.State = 0
 
@@ -25,10 +26,14 @@ function LootActorState.new()
     return self
 end
 
+function LootActorState:Enter()
+    self.LootStartTime = { }
+end
+
 function LootActorState:Exit()
     -- if looting was interrupted, delay looting to prevent flipflop from combat to looting
     -- NOTE this does not prevent looting from flipflopping between 2 items
-    if self.CurrentLootActor and self.CurrentLootActor.IsLootInteraction then
+    if self.CurrentLootActor.IsLootInteraction then
         self.LastCanceledLootTime = os.clock()
     end
 end
@@ -76,18 +81,33 @@ function LootActorState:NeedToRun()
     table.sort(actors, function(a, b) return a.Position:GetDistance3D(selfPlayerPosition) < b.Position:GetDistance3D(selfPlayerPosition) end)
     for k, v in pairs(actors) do
         if v.Position.Distance3DFromMe < self.Settings.LootRadius and
-            (not self.BlacklistActors[v.Guid] or Pyx.Win32.GetTickCount() - self.BlacklistActors[v.Guid] > 0) and
---            (not nearestAttacker or v.Position.Distance3DFromMe < nearestAttacker.Position.Distance3DFromMe / 2) and
---            ((self.CurrentLootActor ~= nil and self.CurrentLootActor.Key == v.Key) or v.IsLineOfSight) and
+            (self.BlacklistActors[v.Guid] == nil or os.clock() - self.BlacklistActors[v.Guid] > 0) and
             Navigator.CanMoveTo(v.Position)
         then 
         
             if self.Settings.SkipLootPlayer == true and v.Position.Distance3DFromMe > 500 and Bot.DetectPlayerAt(v.Position,1000) == true then
                 print("Skipped loot because of Player")
-                self.BlacklistActors[v.Guid] = Pyx.Win32.GetTickCount() + 30 * 1000
---              return false
+                self.BlacklistActors[v.Guid] = os.clock() + 30
+            else
+                if self.CurrentLootActor.Guid ~= v.Guid then
+                    -- new body
+                    -- check if previous body wasn't looted, if so then blacklist it for a few seconds
+                    if self.CurrentLootActor.IsLootInteraction then
+                        local bodyName = self:GetBodyName(self.CurrentLootActor)
+                        print(string.format("Loot flipflop on %s. Blacklisting temporarily", bodyName))
+                        self.BlacklistActors[self.CurrentLootActor.Guid] = os.clock() + 1
+                    end
+                    self.CurrentLootActor = v
+                    self.LootStartTime[v.Guid] = os.clock()
                 else
-                self.CurrentLootActor = v
+                    -- same body, blacklist if it takes too long to loot
+                    local lootStartTime = self.LootStartTime[v.Guid]
+                    if lootStartTime ~= nil and os.clock() - lootStartTime > 10 then
+                        local bodyName = self:GetBodyName(v)
+                        print(string.format("Loot taking too long. Blacklisting %s (%i)", bodyName, v.Guid))
+                        self.BlacklistActors[v.Guid] = os.clock() + 60 * 2
+                    end
+                end
                 return true
             end
             
@@ -130,6 +150,7 @@ function LootActorState:Run()
             self.CallWhenCompleted(self)
         end
         
+        self.CurrentLootActor = {}
         self.WaitForLootTime = 0
         return true
     end
@@ -146,7 +167,7 @@ function LootActorState:Run()
             if not self.CurrentLootActor.IsLootInteraction then
                 print("body disappeared")
                 self.WaitForLootTime = 0
-                self.BlacklistActors[self.CurrentLootActor.Guid] = Pyx.Win32.GetTickCount() + 30 * 1000
+                self.BlacklistActors[self.CurrentLootActor.Guid] = os.clock() + 30 
                 return true
             end
             print("looting didn't start, trying no-animation loot")
@@ -167,13 +188,13 @@ function LootActorState:Run()
         
         if not self.CurrentLootActor.IsLootInteraction then
             print("Not lootable yet, black list !"  )
-            self.BlacklistActors[self.CurrentLootActor.Guid] = Pyx.Win32.GetTickCount() + 30 * 1000 -- Not lootable for now
+            self.BlacklistActors[self.CurrentLootActor.Guid] = os.clock() + 30 -- Not lootable for now
             return false
         end
         
         -- wait up to 2 seconds for the loot window to pop
         self.WaitForLootTime = os.clock() + 2.0
-        self.BlacklistActors[self.CurrentLootActor.Guid] = Pyx.Win32.GetTickCount() + 5 * 1000
+        self.BlacklistActors[self.CurrentLootActor.Guid] = os.clock() + 5
         return true
     end
 end

--- a/scripts/commonstates/v1/LootActor.lua
+++ b/scripts/commonstates/v1/LootActor.lua
@@ -96,6 +96,7 @@ function LootActorState:NeedToRun()
                         local bodyName = self:GetBodyName(self.CurrentLootActor)
                         print(string.format("Loot flipflop on %s. Blacklisting temporarily", bodyName))
                         self.BlacklistActors[self.CurrentLootActor.Guid] = os.clock() + 1
+                        self.CurrentLootActor = {}
                     end
                     self.CurrentLootActor = v
                     self.LootStartTime[v.Guid] = os.clock()
@@ -106,6 +107,7 @@ function LootActorState:NeedToRun()
                         local bodyName = self:GetBodyName(v)
                         print(string.format("Loot taking too long. Blacklisting %s (%i)", bodyName, v.Guid))
                         self.BlacklistActors[v.Guid] = os.clock() + 60 * 2
+                        self.CurrentLootActor = {}
                     end
                 end
                 return true
@@ -168,6 +170,7 @@ function LootActorState:Run()
                 print("body disappeared")
                 self.WaitForLootTime = 0
                 self.BlacklistActors[self.CurrentLootActor.Guid] = os.clock() + 30 
+                self.CurrentLootActor = {}
                 return true
             end
             print("looting didn't start, trying no-animation loot")
@@ -189,6 +192,7 @@ function LootActorState:Run()
         if not self.CurrentLootActor.IsLootInteraction then
             print("Not lootable yet, black list !"  )
             self.BlacklistActors[self.CurrentLootActor.Guid] = os.clock() + 30 -- Not lootable for now
+            self.CurrentLootActor = {}
             return false
         end
         


### PR DESCRIPTION
Fix flip flop between loot state and other states by blocking loot state for 1 second if exited without looting the current body.

Fix flip flop between 2 bodies by blacklisting the last body for 1 second if a new body was picked and the last one was not looted yet.

Blacklist bodies that take longer than 10 seconds to loot. Resets if looting state is exited.

Immediately stop waiting for the loot window if the body disappeared during this time.